### PR TITLE
Fix missing aiohttp import

### DIFF
--- a/summarizer.py
+++ b/summarizer.py
@@ -5,6 +5,7 @@ from typing import Dict, Any, List, Optional
 from datetime import datetime
 from pathlib import Path
 import re
+import aiohttp
 
 from base_agent import BaseAgent
 from llm_client import LLMClient


### PR DESCRIPTION
## Summary
- fix missing aiohttp import in `SummarizerAgent`

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_684a1630d488832f8285244001991692