### PR TITLE
Fix help request handling in AnswererAgent

### DIFF
--- a/answerer.py
+++ b/answerer.py
@@ -62,24 +62,6 @@ class AnswererAgent(BaseAgent):
                 answer_data.get("gaps_identified", False)
             )
             
-            # If low confidence, try to improve the answer
-            if confidence < self.min_confidence_threshold and self.tool_registry:
-                self.logger.info(f"Low confidence ({confidence:.2f}), attempting to improve answer")
-                
-                # Use tool calling to request help
-                help_result = await self.evaluate_and_request_help(
-                    {"confidence_score": confidence, "answer": answer_data["answer"]},
-                    self.min_confidence_threshold
-                )
-                
-                if help_result and help_result.get("help_needed"):
-                    # Log what help is needed
-                    for help_request in help_result["help_needed"]:
-                        self.logger.info(f"Help needed from {help_request['agent']}: {help_request['reason']}")
-                    
-                    # Add to result for orchestrator
-                    result["help_requests"] = help_result["help_needed"]
-            
             result = {
                 "job_id": job_id,
                 "query": query,
@@ -92,6 +74,24 @@ class AnswererAgent(BaseAgent):
                 "follow_up_questions": answer_data.get("follow_up_questions", []),
                 "timestamp": datetime.utcnow().isoformat()
             }
+
+            # If low confidence, try to improve the answer
+            if confidence < self.min_confidence_threshold and self.tool_registry:
+                self.logger.info(f"Low confidence ({confidence:.2f}), attempting to improve answer")
+
+                # Use tool calling to request help
+                help_result = await self.evaluate_and_request_help(
+                    {"confidence_score": confidence, "answer": answer_data["answer"]},
+                    self.min_confidence_threshold
+                )
+
+                if help_result and help_result.get("help_needed"):
+                    # Log what help is needed
+                    for help_request in help_result["help_needed"]:
+                        self.logger.info(f"Help needed from {help_request['agent']}: {help_request['reason']}")
+
+                    # Add to result for orchestrator
+                    result["help_requests"] = help_result["help_needed"]
             
             await self.add_result(job_id, result)
             await self.update_status("healthy", True)

--- a/test_answerer.py
+++ b/test_answerer.py
@@ -1,0 +1,48 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+from answerer import AnswererAgent
+from config import Config
+
+class DummyStateManager:
+    def __init__(self):
+        self.results = []
+        self.status_updates = []
+
+    async def add_agent_result(self, job_id, agent, result):
+        self.results.append((job_id, agent, result))
+
+    async def update_agent_status(self, agent, status, success=True):
+        self.status_updates.append((agent, status, success))
+
+
+class DummyToolRegistry:
+    def register_tool(self, *args, **kwargs):
+        pass
+
+
+def test_process_appends_help_requests():
+    state_manager = DummyStateManager()
+    config = Config()
+    agent = AnswererAgent(config, state_manager)
+    agent.tool_registry = DummyToolRegistry()
+
+    agent._generate_answer = AsyncMock(return_value={
+        "answer": "test answer",
+        "answer_type": "comprehensive",
+        "key_insights": [],
+        "follow_up_questions": []
+    })
+    agent._extract_citations = lambda docs, answer: [{"title": "t", "url": "u"}]
+    agent._evaluate_answer_confidence = AsyncMock(return_value=0.5)
+    agent.evaluate_and_request_help = AsyncMock(return_value={
+        "help_needed": [{"agent": "validator", "action": "deep_validate", "reason": "low_confidence"}]
+    })
+
+    summarized_data = {"document_summaries": [{"title": "t", "url": "u", "summary": "s"}]}
+
+    result = asyncio.run(agent.process("q", "job", summarized_data))
+
+    assert result["help_requests"] == [{"agent": "validator", "action": "deep_validate", "reason": "low_confidence"}]
+    assert state_manager.results
+


### PR DESCRIPTION
## Summary
- create result dict before adding help requests
- append help requests to result after dictionary creation
- add test for help request insertion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a1911e408832fa7c09c48e0e8e5f7